### PR TITLE
Consolidate summary methods for `unmarkedFit`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: unmarked
-Version: 1.4.1.9014
-Date: 2024-08-20
+Version: 1.4.1.9015
+Date: 2024-08-21
 Type: Package
 Title: Models for Data from Unmarked Animals
 Authors@R: c(

--- a/R/IDS.R
+++ b/R/IDS.R
@@ -299,7 +299,7 @@ IDS <- function(lambdaformula = ~1,
 
 }
 
-setMethod("summary", "unmarkedFitIDS", function(object)
+setMethod("summary_internal", "unmarkedFitIDS", function(object)
 {
     cat("\nCall:\n")
     print(object@call)

--- a/man/unmarkedFit-class.Rd
+++ b/man/unmarkedFit-class.Rd
@@ -16,8 +16,6 @@
 \alias{update,unmarkedFit-method}
 \alias{plot,profile,missing-method}
 \alias{summary,unmarkedFit-method}
-\alias{summary,unmarkedFitDS-method}
-\alias{summary,unmarkedFitIDS-method}
 \alias{smoothed}
 \alias{smoothed,unmarkedFitColExt-method}
 \alias{projected}

--- a/tests/testthat/test_fitList.R
+++ b/tests/testthat/test_fitList.R
@@ -14,8 +14,8 @@ test_that("fitList operations work",{
   fl <- fitList(fm=fm, fm2=fm2)
   expect_is(fl, "unmarkedFitList")
 
-  out <- capture.output(summary(fl))
-  expect_equal(out[c(2,23)], rep("Call:", 2))
+  out <- capture.output(expect_warning(summary(fl)))
+  expect_equal(out[c(2,20)], rep("Call:", 2))
 
   cf <- coef(fl)
   expect_equal(dim(cf), c(2,5))
@@ -33,10 +33,12 @@ test_that("fitList operations work",{
 
   # Raster predict
   r <- data.frame(x=rep(1:10, 10), y=rep(1:10, each=10), z=rnorm(100))
-  r <- raster::rasterFromXYZ(r)
-  names(r) <- "x"
-  pr <- predict(fl, type="state", newdata=r)
-  expect_is(pr, "RasterStack")
+  if(requireNamespace("raster")){
+    r <- raster::rasterFromXYZ(r)
+    names(r) <- "x"
+    pr <- predict(fl, type="state", newdata=r)
+    expect_is(pr, "RasterStack")
+  }
 
   mt <- modSel(fl)
   out <- capture.output(mt)

--- a/tests/testthat/test_occu.R
+++ b/tests/testthat/test_occu.R
@@ -29,6 +29,15 @@ test_that("occu can fit simple models",{
   umf <- unmarkedFrameOccu(y = y)
   fm <- occu(~ 1 ~ 1, data = umf)
 
+  # Expect warning about big SEs
+  nul <- capture.output(expect_warning(summary(fm)))
+
+  # Check warning about NaN/NA SEs
+  fm2 <- fm
+  fm2@estimates@estimates$state@covMat[1,1] <- NaN
+  fm2@estimates@estimates$det@covMat[1,1] <- 1
+  nul <- capture.output(expect_warning(summary(fm2)))
+
   occ <- fm['state']
   det <- fm['det']
 


### PR DESCRIPTION
* Export a single `summary` method for ` unmarkedFit` and use `summary_internal` method internally
* Remove a few lines from the summary output
* Warn users when they have NA or very large SE values in the output (fixes #8)
* `show` now returns output directly from summary instead of a slightly different version