### PR TITLE
Consolidate `ranef` methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: unmarked
-Version: 1.4.1.9016
-Date: 2024-08-21
+Version: 1.4.1.9017
+Date: 2024-08-22
 Type: Package
 Title: Models for Data from Unmarked Animals
 Authors@R: c(
@@ -47,12 +47,13 @@ LazyData: yes
 Collate: 'classes.R' 'unmarkedEstimate.R' 'unmarkedFrame.R'
     'unmarkedFit.R' 'utils.R' 'getDesign.R'
     'fitted.R' 'residuals.R' 'update.R' 'simulate.R' 'nonparboot.R' 'getP.R'
+    'ranef.R' 'posteriorSamples.R'
     'colext.R' 'distsamp.R'
     'multinomPois.R' 'occu.R' 'occuRN.R' 'occuMulti.R' 'pcount.R' 'gmultmix.R'
     'pcountOpen.R' 'gdistsamp.R' 'unmarkedFitList.R' 'unmarkedLinComb.R'
-    'ranef.R' 'parboot.R' 'occuFP.R' 'gpcount.R' 'occuPEN.R' 'pcount.spHDS.R'
+    'parboot.R' 'occuFP.R' 'gpcount.R' 'occuPEN.R' 'pcount.spHDS.R'
     'occuMS.R' 'occuTTD.R' 'distsampOpen.R' 'multmixOpen.R' 
-    'unmarkedCrossVal.R' 'piFun.R' 'vif.R' 'makePiFun.R' 'posteriorSamples.R'
+    'unmarkedCrossVal.R' 'piFun.R' 'vif.R' 'makePiFun.R'
     'nmixTTD.R'
     'gdistremoval.R'
     'plotEffects.R'

--- a/R/IDS.R
+++ b/R/IDS.R
@@ -596,8 +596,8 @@ setMethod("nonparboot_internal", "unmarkedFitIDS",
    stop("Not currently supported for unmarkedFitIDS", call.=FALSE)
 })
 
-setMethod("ranef", "unmarkedFitIDS",
-    function(object, B = 0, keepOldSamples = TRUE, ...)
+setMethod("ranef_internal", "unmarkedFitIDS",
+    function(object, ...)
 {
    stop("Not currently supported for unmarkedFitIDS", call.=FALSE)
 })

--- a/R/gdistremoval.R
+++ b/R/gdistremoval.R
@@ -595,7 +595,7 @@ setMethod("residuals_internal", "unmarkedFitGDR", function(object){
 
 # ranef
 
-setMethod("ranef", "unmarkedFitGDR", function(object){
+setMethod("ranef_internal", "unmarkedFitGDR", function(object, ...){
 
   M <- numSites(object@data)
   T <- object@data@numPrimary

--- a/R/goccu.R
+++ b/R/goccu.R
@@ -208,7 +208,7 @@ setMethod("fitted_internal", "unmarkedFitGOccu", function(object){
 
 
 # based on ranef for GPC
-setMethod("ranef", "unmarkedFitGOccu", function(object, ...){
+setMethod("ranef_internal", "unmarkedFitGOccu", function(object, ...){
 
   M <- numSites(object@data)
   JT <- obsNum(object@data)

--- a/R/occuCOP.R
+++ b/R/occuCOP.R
@@ -458,7 +458,7 @@ setMethod("nonparboot_internal", "unmarkedFitOccuCOP",
 
 
 ## ranef ----
-setMethod("ranef", "unmarkedFitOccuCOP", function(object, ...) {
+setMethod("ranef_internal", "unmarkedFitOccuCOP", function(object, ...) {
   # Sites removed (srm) and sites kept (sk)
   srm <- object@sitesRemoved
   if (length(srm) > 0) {

--- a/R/posteriorSamples.R
+++ b/R/posteriorSamples.R
@@ -19,6 +19,7 @@ setMethod("posteriorSamples", "unmarkedRanef", function(object, nsims=100, ...)
   out <- array(NA, c(N, T, nsims))
 
   for (n in 1:N){
+    if(any(is.na(object@post[n,,]))) next
     for (t in 1:T){
         out[n, t, ] <- sample(0:(K-1), nsims, replace=TRUE,
                               prob=object@post[n,,t])

--- a/man/ranef.Rd
+++ b/man/ranef.Rd
@@ -1,79 +1,25 @@
-\name{ranef-methods}
-\docType{methods}
+\name{ranef}
 \alias{ranef}
-\alias{ranef-methods}
-\alias{ranef,unmarkedFitOccu-method}
-\alias{ranef,unmarkedFitOccuFP-method}
-\alias{ranef,unmarkedFitOccuRN-method}
-\alias{ranef,unmarkedFitOccuMulti-method}
-\alias{ranef,unmarkedFitOccuMS-method}
-\alias{ranef,unmarkedFitPCount-method}
-\alias{ranef,unmarkedFitMPois-method}
-\alias{ranef,unmarkedFitDS-method}
-\alias{ranef,unmarkedFitGMM-method}
-\alias{ranef,unmarkedFitGDS-method}
-\alias{ranef,unmarkedFitGPC-method}
-\alias{ranef,unmarkedFitGMMorGDS-method}
-\alias{ranef,unmarkedFitColExt-method}
-\alias{ranef,unmarkedFitPCO-method}
-\alias{ranef,unmarkedFitOccuTTD-method}
-\alias{ranef,unmarkedFitNmixTTD-method}
-\alias{ranef,unmarkedFitGDR-method}
-\alias{ranef,unmarkedFitDailMadsen-method}
-\alias{ranef,unmarkedFitGOccu-method}
-\alias{ranef,unmarkedFitOccuCOP-method}
-\alias{ranef,unmarkedFitIDS-method}
-\title{ Methods for Function \code{ranef} in Package \pkg{unmarked} }
+\alias{ranef,unmarkedFit-method}
+
+\title{Estimate posterior distributions of latent occupancy or abundance}
 \description{
 Estimate posterior distributions of the random variables (latent
-abundance or occurrence) using empirical Bayes methods. These methods
+occupancy or abundance) using empirical Bayes methods. These methods
 return an object storing the posterior distributions of the latent
 variables at each site, and for each year (primary period) in the case
-of open population models. See \link{unmarkedRanef-class} for methods
-used to manipulate the returned object.
+of open population models. See \link{unmarkedRanef-class} and \link{posteriorSamples}
+for methods used to manipulate the returned object.
 }
-\section{Methods}{
-\describe{
 
-\item{\code{signature(object = "unmarkedFitOccu")}}{Computes the
-  conditional distribution of occurrence given the data and the
-  estimates of the
-  fixed effects, \eqn{Pr(z_i=1 | y_{ij}, \hat{\psi}_i,
-  \hat{p}_{ij})}{Pr(z(i)=1 | y(i,j), psi(i), p(i,j))}}
-\item{\code{signature(object = "unmarkedFitOccuRN")}}{Computes the
-  conditional abundance distribution given the data and the estimates of
-  the fixed effects, \eqn{Pr(N_i=k | y_{ij}, \hat{\psi}_i, \hat{r}_{ij})
-  k = 0,1,\dots,K}{Pr(N(i)=k |
-  y(i,j), psi(i), r(i,j)) for k = 0,1,...,K}}
-\item{\code{signature(object = "unmarkedFitPCount")}}{\eqn{Pr(N_i=k |
-  y_{ij}, \hat{\lambda}_i, \hat{p}_{ij}) k = 0,1,\dots,K}{Pr(N(i)=k |
-  y(i,j), lambda(i), p(i,j)) for k = 0,1,...,K}}
-\item{\code{signature(object = "unmarkedFitMPois")}}{\eqn{Pr(N_i=k |
-  y_{ij}, \hat{\lambda}_i, \hat{p}_{ij}) k = 0,1,\dots,K}{Pr(N(i)=k |
-  y(i,j), lambda(i), p(i,j)) for k = 0,1,...,K}}
-\item{\code{signature(object = "unmarkedFitDS")}}{\eqn{Pr(N_i=k |
-  y_{i,1:J}, \hat{\lambda}_i, \hat{\sigma}_{i}) k =
-  0,1,\dots,K}{Pr(N(i)=k |
-  y(i,1:J), lambda(i), sigma(i)) for k = 0,1,...,K}}
-\item{\code{signature(object = "unmarkedFitGMM")}}{\eqn{Pr(M_i=k |
-  y_{i,1:J,t}, \hat{\lambda}_i, \hat{\phi}_{it}, \hat{p}_{ijt})  k =
-  0,1,\dots,K}{Pr(N(i)=k |
-  y(i,1:J,t), lambda(i), phi(i,t), p(i,j,t)) for k = 0,1,...,K}}
-\item{\code{signature(object = "unmarkedFitGDS")}}{\eqn{Pr(M_i=k |
-  y_{i,1:J,t}, \hat{\lambda}_i, \hat{\phi}_{it}, \hat{\sigma}_{it})
-  k = 0,1,\dots,K}{Pr(N(i)=k |
-  y(i,1:J,t), lambda(i), phi(i,t), sigma(i,t)) for k = 0,1,...,K}}
-\item{\code{signature(object = "unmarkedFitColExt")}}{\eqn{Pr(z_{it}=1 |
-  y_{ijt}, \hat{\psi}_i, \hat{\gamma}_{it}, \hat{\epsilon}_{it},
-  \hat{p}_{ijt})}{Pr(z(i,t)=1 |
-  y(i,j,t), psi(i), gamma(i,t), epsilon(i,t), p(i,j,t)) for k = 0,1,...,K}}
-\item{\code{signature(object = "unmarkedFitPCO")}}{\eqn{Pr(N_{it}=k |
-  y_{ijt}, \hat{\lambda}_i, \hat{\gamma}_{it}, \hat{\omega}_{it},
-  \hat{\iota}_{it}, \hat{p}_{ijt}) k = 0,1,...,K}{Pr(N(i,t)=k |
-  y(i,j,t), lambda(i), gamma(i,t), omega(i,t), iota(i,t), p(i,j,t)) for k =
-  0,1,...,K}}
-
+\usage{
+\S4method{ranef}{unmarkedFit}(object, ...)
 }
+
+\arguments{
+  \item{object}{A \code{unmarkedFit} object}
+  \item{...}{Other arguments. For some abundance models you can specify \code{K}; 
+  for multi-species models you can specify \code{species}.}
 }
 
 \note{
@@ -86,7 +32,7 @@ used to manipulate the returned object.
   than make this assumption, the basic empirical Bayes approach uses the
   observed data to estimate these final stage parameters (or to estimate
   the Bayes rule), and proceeds as in a standard Bayesian analysis.}
-  }
+}
 
 
 \section{Warning}{
@@ -115,11 +61,7 @@ used to manipulate the returned object.
 
   Royle, J.A and R.M. Dorazio. 2008. Hierarchical Modeling and Inference
   in Ecology. Academic Press.
-  }
-
-\seealso{
-  \link{unmarkedRanef-class}
-  }
+}
 
 \examples{
 # Simulate data under N-mixture model
@@ -187,5 +129,3 @@ data.frame(mean=rowMeans(pr),
 (ppd <- posteriorSamples(re, nsims=100))
 
 }
-\keyword{methods}
-

--- a/tests/testthat/test_colext.R
+++ b/tests/testthat/test_colext.R
@@ -79,6 +79,7 @@ test_that("colext model fitting works", {
   r <- ranef(fm4)
   expect_equal(dim(r@post), c(nsites, nrep, nyr))
   expect_equal(dim(bup(r)), c(nsites, nyr))
+  expect_equal(r@post[1,1,], c(0,0,0.9865,0.99098), tol=1e-4)
 
   # nonparboot
   expect_true(is.null(fm4@projected.mean.bsse))
@@ -139,6 +140,10 @@ umf5 <- umf1
   expect_equal(dim(gp), dim(umf5@y))
   expect_true(all(!is.na(gp[2,])))
   expect_equal(as.vector(gp[1:2,1:2]), c(NA, 0.74517,0.81052,0.8001), tol=1e-4)
+
+  r <- ranef(fm4)
+  expect_true(all(is.na(r@post[fm4@sitesRemoved,,1])))
+  expect_equal(nrow(r@post), numSites(fm4@data))
 
   umf5 <- umf1
   umf5@yearlySiteCovs$ysc[1] <- NA

--- a/tests/testthat/test_distsamp.R
+++ b/tests/testthat/test_distsamp.R
@@ -101,6 +101,7 @@ test_that("distsamp methods work",{
   r <- ranef(fm, K=50)
   expect_is(r, "unmarkedRanef")
   expect_equal(dim(r@post), c(5,51,1))
+  expect_equivalent(r@post[2,4,1], 0.24167, tol=1e-4)
 
   expect_error(hist(fm))
 
@@ -115,7 +116,7 @@ test_that("distsamp works with missing values",{
   yna[1,1] <- NA
   siteCovs$x[2] <- NA
   yna[3,] <- NA
-  umf <- unmarkedFrameDS(y = y, siteCovs = siteCovs,
+  umf <- unmarkedFrameDS(y = yna, siteCovs = siteCovs,
         dist.breaks=c(0, 5, 10)/1000, survey="line", tlength=rep(1, 5),
         unitsIn="km")
 
@@ -129,8 +130,9 @@ test_that("distsamp works with missing values",{
   expect_equal(dim(gp), c(5,2))
   expect_true(all(is.na(gp[2,])))
 
-  r <- expect_warning(ranef(fm, K=15))
-  expect_equal(numSites(fm@data)-length(fm@sitesRemoved), nrow(r@post))
+  r <- ranef(fm, K=15)
+  expect_equal(numSites(fm@data), nrow(r@post))
+  expect_true(all(is.na(r@post[1:3,,1])))
 })
 
 test_that("distsamp ranef method works",{

--- a/tests/testthat/test_distsampOpen.R
+++ b/tests/testthat/test_distsampOpen.R
@@ -175,6 +175,7 @@ test_that("dso halfnorm key function works",{
   expect_equal(r[1,1:2], c(-0.8717,-0.3207),tol=1e-4)
 
   ran <- ranef(fm)
+  expect_equal(nrow(ran@post), numSites(fm@data))
   expect_equal(bup(ran)[1,1], 2.8916, tol=1e-4)
 
   set.seed(123)
@@ -243,6 +244,10 @@ test_that("distsampOpen works with NAs", {
 
   gp <- getP(fm)
   expect_equal(dim(gp), dim(fm@data@y))
+
+  r <- ranef(fm)
+  expect_equal(nrow(r@post), numSites(fm@data))
+  expect_true(all(is.na(r@post[3,,])))
   
   set.seed(123)
   ysim <- simData(lambda=5, gamma=2, omega=0.5, sigma=40, M=50, T=5,type="line",

--- a/tests/testthat/test_gdistremoval.R
+++ b/tests/testthat/test_gdistremoval.R
@@ -353,6 +353,7 @@ test_that("gdistremoval can fit models",{
 
   r <- ranef(fit)
   expect_equivalent(length(bup(r)), 50)
+  expect_equal(bup(r)[1:4], c(2.4701,3.7661,8.2107,3.9931), tol=1e-4)
 
   pb <- parboot(fit, nsim=2)
   expect_equal(pb@t.star[1,1], 126, tol=1e-4)
@@ -464,6 +465,9 @@ test_that("gdistremoval handles NAs",{
   expect_equal(dim(gp$rem), c(50,5,1))
   expect_true(all(is.na(gp$rem[2,,1])))
   expect_true(all(!is.na(gp$dist[2,,1]))) # not removed because only removal prob is NA
+
+  r <- ranef(fit)
+  expect_equal(nrow(r@post), numSites(fit@data))
 })
 
 test_that("multi-period data works with gdistremoval",{

--- a/tests/testthat/test_gdistsamp.R
+++ b/tests/testthat/test_gdistsamp.R
@@ -231,6 +231,10 @@ test_that("gdistsamp with halfnorm keyfunction works",{
     expect_true(all(is.na(ft[2,1:5])))
     expect_false(is.na(ft[2,6]))
 
+    r <- ranef(fm_C)
+    expect_equal(nrow(r@post), numSites(fm_C@data))
+    expect_true(all(is.na(r@post[1,,1])))
+
     #Point
     set.seed(123)
     data(issj)

--- a/tests/testthat/test_gmultmix.R
+++ b/tests/testthat/test_gmultmix.R
@@ -151,8 +151,9 @@ test_that("gmultmix removal model works",{
   res <- residuals(fm_C)
   expect_equal(dim(res), dim(y))
 
-  expect_warning(r <- ranef(fm_C))
-  expect_equal(dim(r@post), c(4,24,1))
+  r <- ranef(fm_C)
+  expect_equal(dim(r@post), c(5,24,1))
+  expect_equal(bup(r), c(2.8579,6.9914,NA,14.3773,5.2012), tol=1e-4)
 
   expect_warning(s <- simulate(fm_C, 2))
   expect_equal(length(s), 2)

--- a/tests/testthat/test_gpcount.R
+++ b/tests/testthat/test_gpcount.R
@@ -103,9 +103,9 @@ test_that("gpcount function works", {
   res <- residuals(fm)
   expect_equal(dim(res), dim(y))
 
-  expect_warning(r <- ranef(fm))
+  r <- ranef(fm)
   expect_equal(dim(r@post), c(nrow(y), 24, 1))
-  expect_equal(bup(r), c(7.31, 12.63, 1.30, 16.12, 2.04), tol=1e-3)
+  expect_equal(bup(r), c(7.31, 12.63, 1.30, 14.90, 2.04), tol=1e-3)
 
   expect_warning(s <- simulate(fm, 2))
   expect_equal(length(s), 2)

--- a/tests/testthat/test_multinomPois.R
+++ b/tests/testthat/test_multinomPois.R
@@ -118,8 +118,8 @@ test_that("multinomPois can fit a removal model",{
     expect_equal(dim(res), dim(umf1@y))
 
     expect_warning(r <- ranef(m2_C, K=50))
-    expect_equal(dim(r@post), c(3,51,1))
-    expect_equal(bup(r), c(10.794,6.9317,2.655), tol=1e-4)
+    expect_equal(dim(r@post), c(numSites(m2_C@data),51,1))
+    expect_equal(bup(r), c(10.794,6.9317,2.655,NA,NA), tol=1e-4)
 
     umf2 <- unmarkedFrameMPois(y=y, siteCovs=data.frame(x1=rnorm(5)), type="removal")
     m4 <- multinomPois(~1~x1, umf2)
@@ -186,7 +186,7 @@ test_that("multinomPois can fit a dependent double observer model",{
 
   fm_C <- multinomPois(~observer-1 ~1, umf, engine="C")
   expect_equivalent(coef(fm_C), c(2.0416086, 0.7430343, 0.4564236), tol = 1e-5)
-  expect_warning(r <- ranef(fm_C, K=30))
+  r <- ranef(fm_C, K=30)
   expect_is(r, "unmarkedRanef")
 })
 

--- a/tests/testthat/test_multmixOpen.R
+++ b/tests/testthat/test_multmixOpen.R
@@ -128,6 +128,7 @@ test_that("multmixOpen can fit removal models",{
   #Check ranef
   set.seed(123)
   ran <- ranef(fit)
+  expect_equal(nrow(ran@post), numSites(fit@data))
   expect_equivalent(bup(ran)[1,1], 3.450738, tol=1e-5)
 
   #parboot
@@ -178,6 +179,10 @@ test_that("multmixOpen handles NAs",{
 
   gp <- getP(fit)
   expect_equal(dim(gp), dim(umf@y))
+
+  r <- ranef(fit)
+  expect_equal(nrow(r@post), numSites(fit@data))
+  expect_true(all(is.na(r@post[3,,])))
 
   # Check ranef
   set.seed(123)

--- a/tests/testthat/test_occu.R
+++ b/tests/testthat/test_occu.R
@@ -200,8 +200,9 @@ test_that("occu handles NAs",{
   expect_true(all(!is.na(gp[3,]))) # missing site cov
   expect_true(is.na(gp[5,2]))     # missing obs cov
 
-  r <- expect_warning(ranef(fm))
-  expect_equal(nrow(r@post), 4)
+  r <- ranef(fm)
+  expect_equal(nrow(r@post), 5)
+  expect_true(all(is.na(r@post[3,,1]))) # missing site cov
 })
 
 ## Add some checks here.

--- a/tests/testthat/test_occu.R
+++ b/tests/testthat/test_occu.R
@@ -203,6 +203,8 @@ test_that("occu handles NAs",{
   r <- ranef(fm)
   expect_equal(nrow(r@post), 5)
   expect_true(all(is.na(r@post[3,,1]))) # missing site cov
+  ci <- confint(r)
+  expect_true(all(is.na(ci[3,])))
 })
 
 ## Add some checks here.

--- a/tests/testthat/test_occuCOP.R
+++ b/tests/testthat/test_occuCOP.R
@@ -500,6 +500,10 @@ test_that("occuCOP can fit and predict models with covariates", {
   expect_equal(dim(gp), dim(umfit@data@y))
   expect_equal(as.vector(gp[1:2,1:2]), c(1.0920,0.6409,5.4968,9.1728), tol=1e-4)
 
+  r <- ranef(umfit)
+  expect_equal(nrow(r@post), numSites(umfit@data))
+  expect_equal(bup(r)[1:4], c(0,0,0,0), tol=1e-4) # is this correct?
+
   # With missing values in covs
   umf_na <- umf
   umf_na@obsCovs$rain[1] <- NA
@@ -519,5 +523,7 @@ test_that("occuCOP can fit and predict models with covariates", {
   expect_error(gp <- getP(umfit))
   #expect_equal(dim(gp), dim(umfit@data@y))
   #expect_true(is.na(gp[1,1]))
+
+  expect_error(expect_warning(r <- ranef(umfit)))
 })
 

--- a/tests/testthat/test_occuFP.R
+++ b/tests/testthat/test_occuFP.R
@@ -52,6 +52,9 @@ test_that("occuFP model can be fit",{
   expect_equal(dim(gp), dim(m1@data@y))
   expect_equal(as.vector(gp[5:6, 5:6]), c(0.4513,0.4513,0.7232,0.7232), tol=1e-4)
 
+  # ranef
+  expect_error(r <- ranef(m1))
+
   # Check error when random effect in formula
   expect_error(occuFP(~(1|dummy), ~1, ~1, data=umf1))
 })

--- a/tests/testthat/test_occuMS.R
+++ b/tests/testthat/test_occuMS.R
@@ -417,6 +417,11 @@ test_that("occuMS handles NAs properly",{
   expect_warning(fit <- occuMS(rep('~1',3), c('~V1', '~1'), data=umf,se=F))
   expect_equivalent(fit@sitesRemoved, c(1,5))
 
+  r <- ranef(fit)
+  expect_equal(nrow(r@post), numSites(fit@data))
+  expect_true(all(is.na(r@post[5,,1]))) # missing site covariate
+  expect_true(all(is.na(r@post[1,,1]))) # missing all obs
+
   oc_na <- obs_covs
   oc_na[1,1] <- NA
   umf <- unmarkedFrameOccuMS(y=y,siteCovs=site_covs,obsCovs=oc_na)
@@ -436,6 +441,9 @@ test_that("occuMS handles NAs properly",{
   gp <- fitted(exfit)
   expect_equal(dim(gp), dim(exfit@data@y))
   expect_true(is.na(gp[1,1]))
+
+  r <- ranef(exfit)
+  expect_equal(nrow(r@post), numSites(exfit@data))
 
   #Check that fitting works when missing site cov and no obs covs
   sc_na <- site_covs

--- a/tests/testthat/test_occuMulti.R
+++ b/tests/testthat/test_occuMulti.R
@@ -123,9 +123,13 @@ test_that("occuMulti can fit models with covariates",{
   expect_equal(as.vector(gp[[2]][1:2,1:2]), c(0.3080,0.4923,0.5645,0.3596), tol=1e-4)
 
   # ranef
-  expect_error(ran <- ranef(fm))
-  ran <- ranef(fm, species=1)
-  expect_equal(bup(ran), rep(1,5))
+  ran <- ranef(fm)
+  expect_equal(names(ran), names(fm@data@ylist))
+  expect_true(all(sapply(ran, function(x) inherits(x, "unmarkedRanef"))))
+  expect_equal(bup(ran$sp1), rep(1,5))
+  ran2 <- ranef(fm, species=1)
+  expect_is(ran2, "unmarkedRanef")
+  expect_equal(ran$sp1, ran2)
 
   # parboot
   pb <- parboot(fm, nsim=2)
@@ -185,6 +189,8 @@ test_that("occuMulti can handle NAs",{
   gp <- getP(fm)
   expect_equal(dim(gp[[1]]), dim(fm@data@ylist[[1]]))
   expect_true(is.na(gp[[1]][1,1]))
+
+  r <- ranef(fm)
 
   #Check error thrown when all detections are missing
   yna[[1]][1,] <- NA

--- a/tests/testthat/test_occuRN.R
+++ b/tests/testthat/test_occuRN.R
@@ -44,8 +44,10 @@ test_that("occuRN can fit models",{
   res <- residuals(fm_C)
   expect_equal(dim(res), dim(woodthrushUMF@y))
   expect_equal(res[1,1], 0.73757, tol=1e-4)
+  
   r <- ranef(fm_C, K=10)
   expect_equal(dim(r@post), c(50,11,1))
+  expect_equal(bup(r)[1:4], c(5.1059,5.6125,3.2689,5.6125), tol=1e-4)
 
   s <- simulate(fm_C, 2)
   expect_equal(length(s), 2)
@@ -124,7 +126,8 @@ test_that("occuRN can handle NAs",{
   expect_true(is.na(ft[1,1])) # missing obs cov
   expect_true(all(!is.na(ft[2,]))) # missing site cov
 
-  r <- expect_warning(ranef(fm_na))
-  expect_equal(50-nrow(r@post), length(fm_na@sitesRemoved))
+  r <- ranef(fm_na, K=30)
+  expect_equal(nrow(r@post), numSites(fm_na@data))
+  expect_true(all(is.na(r@post[1:2,,1])))
 })
 

--- a/tests/testthat/test_occuTTD.R
+++ b/tests/testthat/test_occuTTD.R
@@ -193,6 +193,10 @@ test_that("occuTTD can fit a single-season 1 obs model",{
   expect_equal(dim(ft), dim(fit_naC@data@y))
   expect_true(is.na(ft[2,1]))
 
+  r <- ranef(fit_naC)
+  expect_equal(nrow(r@post), N)
+  expect_true(all(is.na(r@post[2,,])))
+
   set.seed(123)
   p <- parboot(fitC, nsim=3)
   expect_equivalent(p@t.star[1,], 87.90704)
@@ -206,8 +210,10 @@ test_that("occuTTD can fit a single-season 1 obs model",{
 
   r <- ranef(fitC)
   expect_equivalent(dim(r@post), c(N,2,1))
+  
   b <- bup(r)
   expect_equivalent(length(b), N)
+  expect_equal(b[1:4], c(1,1,0.052295,0.221098), tol=1e-4)
   
   gp <- getP(fitC)
   expect_equal(dim(gp), dim(fitC@data@y))
@@ -272,6 +278,7 @@ test_that("occuTTD can fit a single-season multi-obs model",{
   expect_equivalent(dim(r@post), c(N,2,1))
   b <- bup(r)
   expect_equivalent(length(b), N)
+  expect_equal(b[1:4], c(1,1,0.028935,0.12426), tol=1e-4)
 
   #Check site is retained when only one observation is missing
   ttd_na <- ttd; ttd_na[1,1] <- NA

--- a/tests/testthat/test_pcount.R
+++ b/tests/testthat/test_pcount.R
@@ -129,6 +129,10 @@ test_that("pcount handles missing values", {
   gp <- getP(fm)
   expect_equal(dim(gp), dim(umf@y))
   expect_true(is.na(gp[1,1])) # missing obs cov
+
+  r <- ranef(fm)
+  expect_equal(nrow(r@post), numSites(fm@data))
+  expect_true(all(is.na(r@post[2,,1]))) # missing site cov
 })
 
 test_that("pcount predict works",{

--- a/tests/testthat/test_pcountOpen.R
+++ b/tests/testthat/test_pcountOpen.R
@@ -173,7 +173,10 @@ test_that("pcountOpen handles NAs",{
                      c(0.9714456, 0.4481042, -0.8920462, 4.0379739 ),
                      tol = 1e-4)
   expect_equal(fm3@sitesRemoved, 6)
-
+  
+  r <- ranef(fm3)
+  expect_equal(nrow(r@post), numSites(fm3@data))
+  expect_equal(bup(r)[1:4], c(2.6409,3.0457,0.04577,5.04577), tol=1e-4)
 
 
   y4 <- matrix(c(

--- a/tests/testthat/test_ranef_predict.R
+++ b/tests/testthat/test_ranef_predict.R
@@ -16,7 +16,9 @@ test_that("ranef predict method works",{
   umf <- unmarkedFramePCount(y=y)
   fm <- expect_warning(pcount(~1 ~1, umf, K=K))
 
-  re <- expect_warning(ranef(fm))
+  re <- ranef(fm)
+  expect_equal(nrow(re@post), numSites(fm@data))
+  expect_true(all(is.na(re@post[1,,1])))
 
   set.seed(123)
   ps <- posteriorSamples(re, nsim=10)
@@ -25,15 +27,15 @@ test_that("ranef predict method works",{
   sh <- capture.output(show(ps))
   expect_equal(sh[1], "Posterior samples from unmarked model")
 
-  #One is dropped bc of NA
-  expect_equivalent(dim(ps@samples), c(9,1,10))
+  expect_equivalent(dim(ps@samples), c(10,1,10))
+  expect_true(all(is.na(ps@samples[1,,1])))
 
   # Brackets
   expect_equal(ps[1,1,1], ps@samples[1,1,1,drop=FALSE])
 
   # Method for unmarkedFit objects
   set.seed(123)
-  ps2 <- expect_warning(posteriorSamples(fm, nsim=10))
+  ps2 <- posteriorSamples(fm, nsim=10)
   expect_equal(ps, ps2)
 
   # Custom function
@@ -45,7 +47,7 @@ test_that("ranef predict method works",{
   pr <- predict(re, fun=myfunc, nsim=10)
   expect_equivalent(dim(pr), c(2,10))
   expect_equal(rownames(pr), c("gr1","gr2"))
-  expect_equivalent(as.numeric(pr[1,1:3]), c(7.0,5.0,4.75))
+  expect_equivalent(as.numeric(pr[2,1:3]), c(5.2,5.6,4.8))
 
   #Dynamic model
   set.seed(7)


### PR DESCRIPTION
* One exported `ranef` method
* Internal `ranef_internal` methods for each fit type
* Sites with all NAs are no longer dropped, so dimensions of ranef output should always be the same as the input data